### PR TITLE
[Util] Update tinyformat.h

### DIFF
--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -488,7 +488,11 @@ namespace detail {
 class FormatArg
 {
     public:
-        FormatArg() {}
+        FormatArg()
+             : m_value(nullptr),
+             m_formatImpl(nullptr),
+             m_toIntImpl(nullptr)
+         { }
 
         template<typename T>
         FormatArg(const T& value)
@@ -500,11 +504,15 @@ class FormatArg
         void format(std::ostream& out, const char* fmtBegin,
                     const char* fmtEnd, int ntrunc) const
         {
+            assert(m_value);
+            assert(m_formatImpl);
             m_formatImpl(out, fmtBegin, fmtEnd, ntrunc, m_value);
         }
 
         int toInt() const
         {
+            assert(m_value);
+            assert(m_toIntImpl);
             return m_toIntImpl(m_value);
         }
 
@@ -705,23 +713,27 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
             break;
         case 'X':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'x': case 'p':
             out.setf(std::ios::hex, std::ios::basefield);
             intConversion = true;
             break;
         case 'E':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'e':
             out.setf(std::ios::scientific, std::ios::floatfield);
             out.setf(std::ios::dec, std::ios::basefield);
             break;
         case 'F':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'f':
             out.setf(std::ios::fixed, std::ios::floatfield);
             break;
         case 'G':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'g':
             out.setf(std::ios::dec, std::ios::basefield);
             // As in boost::format, let stream decide float format.


### PR DESCRIPTION
Updates `tinyformat.h` to commit c42f/tinyformat@689695c upstream.

Applies https://github.com/bitcoin/bitcoin/commit/60b98f8e145617e9e50a2eb7f3181953e1e8c424 from upstream, which adds a fall through comment, suppressing compiler warning.
Additionally, it applies the change https://github.com/c42f/tinyformat/commit/5d9e05a3479d1b2ec6a4602fd797f0ec26440db2 from upstream, hardening the format and toInt functions. 