### PR TITLE
Fix surjection caching, add single test

### DIFF
--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -190,9 +190,9 @@ bool CachingSurjectionProofChecker::VerifySurjectionProof(secp256k1_surjectionpr
 {
     // Serialize objects
     std::vector<unsigned char> vchproof;
-    size_t proof_len = 0;
-    vchproof.resize(secp256k1_surjectionproof_serialized_size(secp256k1_ctx_verify_amounts, &proof));
-    secp256k1_surjectionproof_serialize(secp256k1_ctx_verify_amounts, &vchproof[0], &proof_len, &proof);
+    size_t proof_len = secp256k1_surjectionproof_serialized_size(secp256k1_ctx_verify_amounts, &proof);
+    vchproof.resize(proof_len);
+    assert(secp256k1_surjectionproof_serialize(secp256k1_ctx_verify_amounts, &vchproof[0], &proof_len, &proof) == 1);
 
     // libsecp API only supports up to 256 indices for surjection, so we truncate
     // commitment list to that size. Assets must be proven against the first 256 inputs.
@@ -202,7 +202,7 @@ bool CachingSurjectionProofChecker::VerifySurjectionProof(secp256k1_surjectionpr
     tagCommit.resize(33);
     CSHA256 sha2;
     for (unsigned int i = 0; i < surjection_size; i++) {
-        secp256k1_generator_serialize(secp256k1_ctx_verify_amounts, tagCommit.data(), &vTags[i]);
+        assert(secp256k1_generator_serialize(secp256k1_ctx_verify_amounts, tagCommit.data(), &vTags[i]) == 1);
         sha2.Write(tagCommit.data(), tagCommit.size());
     }
     tagCommit.resize(32);
@@ -210,7 +210,7 @@ bool CachingSurjectionProofChecker::VerifySurjectionProof(secp256k1_surjectionpr
 
     std::vector<unsigned char> vchGen;
     vchGen.resize(CConfidentialValue::nCommittedSize);
-    secp256k1_generator_serialize(secp256k1_ctx_verify_amounts, &vchGen[0], &gen);
+    assert(secp256k1_generator_serialize(secp256k1_ctx_verify_amounts, &vchGen[0], &gen) == 1);
 
     CPubKey pubkey(vchGen);
     uint256 entry;

--- a/src/test/blind_tests.cpp
+++ b/src/test/blind_tests.cpp
@@ -138,7 +138,10 @@ BOOST_AUTO_TEST_CASE(naive_blinding_test)
         BOOST_CHECK(BlindTransaction(input_blinds, input_asset_blinds, input_assets, input_amounts, output_blinds, output_asset_blinds, output_pubkeys, vDummy, vDummy, tx3) == 2);
         BOOST_CHECK(!tx3.vout[0].nValue.IsExplicit());
         BOOST_CHECK(!tx3.vout[2].nValue.IsExplicit());
-        BOOST_CHECK(VerifyAmounts(cache, tx3));
+        // Store the results, copy the surjection proof check for cache validity
+        BOOST_CHECK(VerifyAmounts(cache, tx3, nullptr, true));
+        tx3.wit.vtxoutwit[0].vchSurjectionproof = tx3.wit.vtxoutwit[2].vchSurjectionproof;
+        BOOST_CHECK(!VerifyAmounts(cache, tx3, nullptr, true));
 
         CAmount unblinded_amount;
         BOOST_CHECK(UnblindConfidentialPair(key2, tx3.vout[0].nValue, tx3.vout[0].nAsset, tx3.vout[0].nNonce, scriptCommit, tx3.wit.vtxoutwit[0].vchRangeproof, unblinded_amount, blind3, unblinded_id, asset_blind) == 0);


### PR DESCRIPTION
Fixes possible consensus-level break where the surjection proofs all appeared to be the same for validity-caching purposes.